### PR TITLE
Delete trailing comma that causing error on syntaxallert.py

### DIFF
--- a/words/en.json
+++ b/words/en.json
@@ -492,7 +492,7 @@
         "efford"
     ],
 	"affordable": [
-		"afordable",
+		"afordable"
 	],
     "affords": [
         "effords"


### PR DESCRIPTION
There is a typo error (trailing comma) on `words/en.json`