### PR TITLE
french added

### DIFF
--- a/words/fr.json
+++ b/words/fr.json
@@ -1,0 +1,210 @@
+{
+	"agression" : [
+		"aggression"
+	],
+	"arrêter" : [
+		"arreter"
+	],
+	"ascenseur" : [
+		"ascenceur"
+	],
+	"banlieue" : [
+		"banlieu"
+	],
+	"banlieues" : [
+		"banlieux"
+	],
+	"belle-sœur" : [
+		"belle-soeur"
+	],
+	"biter" : [
+		"bitter"
+	],
+	"bleus" : [
+		"bleux"
+	],
+	"budgétaire" : [
+		"bugétaire"
+	],
+	"çà et là" : [
+		"ça et là"
+	],
+	"caresse" : [
+		"casress"
+	],
+	"catéchisme" : [
+		"cathéchisme"
+	],
+	"cauchemar" : [
+		"cauchemard"
+	],
+	"cauchemars" : [
+		"cauchemards"
+	],
+	"Cène" : [
+		"cène"
+	],
+	"championnat" : [
+		"championat"
+	],
+	"ci-dessus" : [
+		"cidessus"
+	],
+	"colophane" : [
+		"collophane"
+	],
+	"colocataire" : [
+		"colocateur"
+	],
+	"côlon" : [
+		"colon"
+	],
+	"côlons" : [
+		"colons"
+	],
+	"compétitivité" : [
+		"compétivité"
+	],
+	"conscience" : [
+		"concience"
+	],
+	"croisement" : [
+		"croissement"
+	],
+	"débarrasser" : [
+		"débarasser"
+	],
+	"défaite" : [
+		"défete",
+		"défète"
+	],
+	"dernière" : [
+		"derniere"
+	],
+	"déshydrogénase" : [
+		"deshydrogenase"
+	],
+	"etc." : [
+		"ect."
+	],
+	"elles-mêmes" : [
+		"ellesmêmes"
+	],
+	"entregent" : [
+		"entre-gens"
+	],
+	"entrepreneuriat" : [
+		"entrepreunariat"
+	],
+	"étaient" : [
+		"etaient"
+	],
+	"était" : [
+		"etait"
+	],
+	"étaits" : [
+		"etaits"
+	],
+	"être" : [
+		"etre"
+	],
+	"expérimental" : [
+		"experimental"
+	],
+	"fascisme" : [
+		"fachisme"
+	],
+	"fascismes" : [
+		"fachismes"
+	],
+	"fasciste" : [
+		"fachiste"
+	],
+	"fascistes" : [
+		"fachistes"
+	],
+	"flottille" : [
+		"flotille"
+	],
+	"flotrilles" : [
+		"flotilles"
+	],
+	"foehn" : [
+		"fœhn"
+	],
+	"Guiana" : [
+		"Guyana"
+	],
+	"ici" : [
+		"içi"
+	],
+	"îlot" : [
+		"ilôt"
+	],
+	"inclus" : [
+		"inclu"
+	],
+	"Israélien" : [
+		"Israëlien"
+	],
+	"Israéliens" : [
+		"Israëliens"
+	],
+	"lipofuscine" : [
+		"lipofucsine"
+	],
+	"merci" : [
+		"merçi"
+	],
+	"merveilleux" : [
+		"merveilleu"
+	],
+	"niveau" : [
+		"nivau"
+	],
+	"par-ci": [
+		"par ci"
+	],
+	"par-la": [
+		"par la"
+	],
+	"patin à roulettes" : [
+		"patin à roues"
+	],
+	"pendre la crémaillère" : [
+		"pendre la crémallière"
+	],
+	"peut-être" : [
+		"peut être"
+	],
+	"poisse" : [
+		"pouasse"
+	],
+	"pourparlers" : [
+		"pourpalers"
+	],
+	"protège" : [
+		"protége"
+	],
+	"qualité" : [
+		"qualitée"
+	],
+	"roder" : [
+		"rôder"
+	],
+	"saynète" : [
+		"saynette"
+	],
+	"soi-disant" : [
+		"soit-disant"
+	],
+	"transsexuel" : [
+		"transexuel"
+	],
+	"transsexuels" : [
+		"transexuels"
+	],
+	"trompe-l’œil" : [
+		"trompe l'oeil"
+	],
+}


### PR DESCRIPTION
From "https://en.wiktionary.org/wiki/Category:French_misspellings" , I scraped common french misspellings.