### PR TITLE
Error handling for circular references

### DIFF
--- a/manageterms.py
+++ b/manageterms.py
@@ -2,18 +2,32 @@
 import argparse, os.path
 from utils.data_handlers import open_typo_file, save_typo_data
 
+
+def parse_argument(_parser_):
+  _parser_.add_argument('-wrong', dest="wrong", type=str, required=True)
+  _parser_.add_argument('-right', dest="right", type=str, required=True)
+  _parser_.add_argument('-lang', dest="lang", type=str, required=True)
+  args = _parser_.parse_args()
+  return args
+  
+  
+def store_new_argument(_args_):
+  try:
+    lang_path = script_path + '/words/' + _args_.lang + '.json'
+    typo_data = open_typo_file(lang_path)
+    typo_data[args.right].add(_args_.wrong)
+    save_typo_data(lang_path, typo_data)
+  except FileNotFoundError:
+    raise ValueError('SyntaxAlert only supports en, es, fr, it at the moment.')
+
 # Parse argument
-parser = argparse.ArgumentParser(description='add new terms!')
+parser = argparse.ArgumentParser(description='add new terms!')    
 
-parser.add_argument('-wrong', dest="wrong", type=str, required=True)
-parser.add_argument('-right', dest="right", type=str, required=True)
-parser.add_argument('-lang', dest="lang", type=str, required=True)
-args = parser.parse_args()
-
-script_path = os.path.dirname(os.path.realpath(__file__))
-lang_path = script_path + '/words/' + args.lang + '.json'
-
-typo_data = open_typo_file(lang_path)
-typo_data[args.right].add(args.wrong)
-
-save_typo_data(lang_path, typo_data)
+# Check argument is not circular
+if args.right == args.wrong:
+  raise ValueError('You can’t replace a word with itself. It will create a loop.')
+else:  
+  # Store argument
+  script_path = os.path.dirname(os.path.realpath(__file__))
+  store_new_argument(args)
+  


### PR DESCRIPTION
_Part of my Hacktober effort, sorry if this not very sophisticated_

## What ## 
Following https://github.com/Mte90/SyntaxAlert/issues/35, I’ve added:
- error handling for:
  - circular references;
  - use of non-supported languages;
- some modularity.

## Comment ##

I could not find a list of supported languages, so I’m just catching the file error; there should be a way to generate both the detection and the copy of the error message from the contents of the `/words/` file.

I’m not sure if there could be other error in either `store_new_argument` function.

I have not found a testing framework.